### PR TITLE
feat(bing-ads): add product feed tool and fix campaign defaults

### DIFF
--- a/bing-ads/README.md
+++ b/bing-ads/README.md
@@ -3,13 +3,14 @@
 [![npm version](https://badge.fury.io/js/@channel47%2Fbing-ads-mcp.svg)](https://www.npmjs.com/package/@channel47/bing-ads-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-MCP server for Microsoft Advertising (Bing Ads) via REST API. Query campaigns, pull performance reports, and mutate entities with dry-run safety built in.
+MCP server for Microsoft Advertising (Bing Ads) via REST APIs. Query campaigns, pull performance reports, read Merchant Center product feeds, and mutate entities with dry-run safety built in.
 
 Part of [Channel 47](https://channel47.dev), the open-source ecosystem of profession plugins for Claude Code. [Get the newsletter](https://channel47.dev/subscribe) for weekly skill breakdowns from production use.
 
 ## What It Does
 
 - **List accounts** under a customer ID with status and pause reason
+- **List Merchant Center products** with feed URLs, pricing, and availability
 - **Query entities** — campaigns, ad groups, keywords, ads with normalized output
 - **Pull reports** — campaign, ad group, keyword, ad, search query, account, asset group performance with configurable date ranges and aggregation
 - **Mutate entities** — campaigns, ad groups, keywords, ads with dry-run preview and explicit approval
@@ -72,13 +73,32 @@ Query entity data from Campaign Management API.
 - `customer_id` (string, optional): Customer ID
 - `campaign_id` (string): Required when querying `ad_groups`
 - `ad_group_id` (string): Required when querying `keywords` or `ads`
-- `campaign_type` (string, optional): Filter campaigns by type
+- `campaign_type` (string, optional): Filter campaigns by type. When omitted, queries all supported types (`Search`, `Shopping`, `DynamicSearchAds`, `Audience`, `Hotel`, `PerformanceMax`, `App`)
 
 **Example:**
 ```json
 {
   "entity": "campaigns",
   "account_id": "123456789"
+}
+```
+
+### list_products
+
+List products from a Microsoft Merchant Center store via Content API.
+
+**Parameters:**
+- `store_id` (string, required): Merchant Center store ID
+- `max_results` (integer, optional): Page size (1-250, default: 250)
+- `start_token` (string, optional): Pagination token from previous response
+
+**Returns:** Array of products with `link`, `title`, `price`, `availability`, `offer_id`, and related feed attributes.
+
+**Example:**
+```json
+{
+  "store_id": "12345",
+  "max_results": 100
 }
 ```
 

--- a/bing-ads/server/index.js
+++ b/bing-ads/server/index.js
@@ -12,6 +12,7 @@ import {
 
 import { validateEnvironment } from './auth.js';
 import { listAccounts } from './tools/list-accounts.js';
+import { listProducts } from './tools/list-products.js';
 import { mutate } from './tools/mutate.js';
 import { query } from './tools/query-campaigns.js';
 import { report } from './tools/report.js';
@@ -33,6 +34,29 @@ const TOOLS = [
           description: 'Customer (manager) ID. Uses default from BING_ADS_CUSTOMER_ID when omitted.'
         }
       }
+    }
+  },
+  {
+    name: 'list_products',
+    description: 'List Microsoft Merchant Center products from the Content API. Returns feed fields including link (landing URL), title, price, availability, and offer ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        store_id: {
+          type: 'string',
+          description: 'Merchant Center store ID (BMC StoreId)'
+        },
+        max_results: {
+          type: 'integer',
+          description: 'Maximum products to return per request (1-250, default: 250)',
+          default: 250
+        },
+        start_token: {
+          type: 'string',
+          description: 'Pagination token from a prior list_products response'
+        }
+      },
+      required: ['store_id']
     }
   },
   {
@@ -183,6 +207,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === 'query') {
     return query(params);
+  }
+
+  if (name === 'list_products') {
+    return listProducts(params);
   }
 
   if (name === 'report') {

--- a/bing-ads/server/resources/api-reference.md
+++ b/bing-ads/server/resources/api-reference.md
@@ -5,6 +5,7 @@
 - Campaign Management: `https://campaign.api.bingads.microsoft.com/CampaignManagement/v13`
 - Reporting: `https://reporting.api.bingads.microsoft.com/Reporting/v13`
 - Customer Management: `https://clientcenter.api.bingads.microsoft.com/CustomerManagement/v13`
+- Content API (Merchant Center): `https://content.api.bingads.microsoft.com/shopping/v9.1/bmc`
 
 ## OAuth Token Refresh
 
@@ -31,9 +32,16 @@ Campaign Management and Reporting endpoints also use:
 - `CustomerAccountId: <account_id>`
 - `CustomerId: <customer_id>`
 
+Content API endpoints use:
+
+- `AuthenticationToken: <access_token>` (same OAuth token, different header key)
+- `DeveloperToken: <BING_ADS_DEVELOPER_TOKEN>`
+- `Content-Type: application/json`
+
 ## Tool Endpoint Mapping
 
 - `list_accounts` -> `POST /CustomerManagement/v13/AccountsInfo/Query`
+- `list_products` -> `GET /shopping/v9.1/bmc/{storeId}/products`
 - `query` campaigns -> `POST /CampaignManagement/v13/Campaigns/QueryByAccountId`
 - `query` ad_groups -> `POST /CampaignManagement/v13/AdGroups/QueryByCampaignId`
 - `query` keywords -> `POST /CampaignManagement/v13/Keywords/QueryByAdGroupId`
@@ -54,4 +62,3 @@ Campaign Management and Reporting endpoints also use:
 - `mutate` ads delete -> `DELETE /CampaignManagement/v13/Ads`
 - `mutate` negative_keywords create -> `POST /CampaignManagement/v13/EntityNegativeKeywords`
 - `mutate` negative_keywords delete -> `DELETE /CampaignManagement/v13/EntityNegativeKeywords`
-

--- a/bing-ads/server/tools/list-products.js
+++ b/bing-ads/server/tools/list-products.js
@@ -1,0 +1,94 @@
+import { BING_BASE_URLS, contentRequest } from '../http.js';
+import { formatError, formatSuccess } from '../utils/response-format.js';
+import { validateRequired } from '../utils/validation.js';
+
+const DEFAULT_MAX_RESULTS = 250;
+const MIN_MAX_RESULTS = 1;
+const MAX_MAX_RESULTS = 250;
+
+function resolveMaxResults(value) {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_MAX_RESULTS;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < MIN_MAX_RESULTS || parsed > MAX_MAX_RESULTS) {
+    throw new Error(`Invalid max_results: ${value}. Must be an integer between 1 and 250.`);
+  }
+
+  return parsed;
+}
+
+function buildProductsUrl(storeId, maxResults, startToken) {
+  const query = new URLSearchParams({
+    'max-results': String(maxResults)
+  });
+
+  if (startToken) {
+    query.set('start-token', String(startToken));
+  }
+
+  return `${BING_BASE_URLS.contentApi}/${encodeURIComponent(storeId)}/products?${query.toString()}`;
+}
+
+function normalizeProduct(product) {
+  const customLabels = [
+    product?.customLabel0,
+    product?.customLabel1,
+    product?.customLabel2,
+    product?.customLabel3,
+    product?.customLabel4
+  ].filter((label) => label !== undefined && label !== null && label !== '');
+
+  return {
+    id: product?.id ?? '',
+    offer_id: product?.offerId ?? '',
+    title: product?.title ?? '',
+    link: product?.link ?? '',
+    mobile_link: product?.mobileLink ?? null,
+    adwords_redirect: product?.adwordsRedirect ?? null,
+    price: product?.price ?? null,
+    sale_price: product?.salePrice ?? null,
+    availability: product?.availability ?? '',
+    image_link: product?.imageLink ?? '',
+    brand: product?.brand ?? '',
+    custom_labels: customLabels,
+    expiration_date: product?.expirationDate ?? null
+  };
+}
+
+export async function listProducts(params = {}, dependencies = {}) {
+  const request = dependencies.request || contentRequest;
+
+  try {
+    validateRequired(params, ['store_id']);
+
+    const storeId = String(params.store_id);
+    const maxResults = resolveMaxResults(params.max_results);
+    const requestUrl = buildProductsUrl(storeId, maxResults, params.start_token);
+    const response = await request(
+      requestUrl,
+      undefined,
+      {
+        method: 'GET',
+        includeContextHeaders: false
+      }
+    );
+
+    const products = (response?.resources || response?.products || []).map(normalizeProduct);
+    const nextPageToken = response?.nextPageToken ?? null;
+
+    return formatSuccess({
+      summary: `Found ${products.length} product${products.length === 1 ? '' : 's'} in store ${storeId}`,
+      data: products,
+      metadata: {
+        storeId,
+        maxResults,
+        nextPageToken,
+        totalProducts: products.length
+      }
+    });
+  } catch (error) {
+    return formatError(error);
+  }
+}

--- a/bing-ads/server/tools/query-campaigns.js
+++ b/bing-ads/server/tools/query-campaigns.js
@@ -23,6 +23,8 @@ const ENTITY_RESPONSE_KEYS = {
   ads: 'Ads'
 };
 
+const DEFAULT_CAMPAIGN_TYPES = 'Search Shopping DynamicSearchAds Audience Hotel PerformanceMax App';
+
 function normalizeCampaign(campaign) {
   return {
     id: String(campaign?.Id ?? ''),
@@ -88,7 +90,7 @@ function buildEntityRequest(entity, params, accountId) {
     return {
       body: {
         AccountId: String(accountId),
-        ...(params.campaign_type ? { CampaignType: params.campaign_type } : {}),
+        CampaignType: params.campaign_type || DEFAULT_CAMPAIGN_TYPES,
         ReturnAdditionalFields: 'BidStrategyId'
       },
       normalize: normalizeCampaign

--- a/bing-ads/test/fixtures.js
+++ b/bing-ads/test/fixtures.js
@@ -80,6 +80,22 @@ export const MOCK_ADS_RESPONSE = {
   ]
 };
 
+export const MOCK_PRODUCTS_RESPONSE = {
+  resources: [
+    {
+      id: 'online:en:US:sku-1',
+      offerId: 'sku-1',
+      title: 'Blue Shirt',
+      link: 'https://www.channel47.com/products/sku-1',
+      price: { value: '19.99', currency: 'USD' },
+      availability: 'in stock',
+      brand: 'Channel47',
+      imageLink: 'https://www.channel47.com/images/sku-1.jpg'
+    }
+  ],
+  nextPageToken: 'next-page-token'
+};
+
 export const SAMPLE_REPORT_CSV = [
   'AccountName,CampaignName,CampaignId,Impressions,Clicks,Spend,Conversions',
   '"Channel 47","Search - Brand",333333333,1000,120,55.75,12',

--- a/bing-ads/test/http.test.js
+++ b/bing-ads/test/http.test.js
@@ -66,6 +66,7 @@ describe('BING_BASE_URLS', () => {
     assert.equal(BING_BASE_URLS.campaignManagement, 'https://campaign.api.bingads.microsoft.com/CampaignManagement/v13');
     assert.equal(BING_BASE_URLS.reporting, 'https://reporting.api.bingads.microsoft.com/Reporting/v13');
     assert.equal(BING_BASE_URLS.customerManagement, 'https://clientcenter.api.bingads.microsoft.com/CustomerManagement/v13');
+    assert.equal(BING_BASE_URLS.contentApi, 'https://content.api.bingads.microsoft.com/shopping/v9.1/bmc');
   });
 });
 
@@ -140,6 +141,26 @@ describe('request headers', () => {
 
     assert.equal(capturedHeaders.CustomerAccountId, undefined);
     assert.equal(capturedHeaders.CustomerId, '222');
+  });
+
+  test('contentRequest uses AuthenticationToken instead of Authorization', async () => {
+    let capturedHeaders = null;
+    let capturedMethod = null;
+
+    global.fetch = tokenThenApi((_url, options) => {
+      capturedHeaders = options.headers;
+      capturedMethod = options.method;
+      return jsonResponse({ resources: [] });
+    });
+
+    const { contentRequest } = await importFresh('../server/http.js');
+    await contentRequest('https://content.api.bingads.microsoft.com/shopping/v9.1/bmc/123/products?max-results=250');
+
+    assert.equal(capturedHeaders.AuthenticationToken, 'test-access-token');
+    assert.equal(capturedHeaders.Authorization, undefined);
+    assert.equal(capturedHeaders.DeveloperToken, 'dev-token');
+    assert.equal(capturedHeaders['Content-Type'], 'application/json');
+    assert.equal(capturedMethod, 'GET');
   });
 });
 

--- a/bing-ads/test/integration.test.js
+++ b/bing-ads/test/integration.test.js
@@ -3,12 +3,14 @@ import assert from 'node:assert/strict';
 import { deflateRawSync } from 'node:zlib';
 
 import { listAccounts } from '../server/tools/list-accounts.js';
+import { listProducts } from '../server/tools/list-products.js';
 import { mutate } from '../server/tools/mutate.js';
 import { query } from '../server/tools/query-campaigns.js';
 import { report } from '../server/tools/report.js';
 import {
   MOCK_ACCOUNTS_RESPONSE,
   MOCK_CAMPAIGNS_RESPONSE,
+  MOCK_PRODUCTS_RESPONSE,
   MOCK_UPDATE_RESPONSE,
   SAMPLE_REPORT_CSV
 } from './fixtures.js';
@@ -85,7 +87,7 @@ afterEach(() => {
 });
 
 describe('tool integration', () => {
-  test('runs all four tools with mocked dependencies', async () => {
+  test('runs all tools with mocked dependencies', async () => {
     const listResult = await listAccounts(
       {},
       {
@@ -95,6 +97,17 @@ describe('tool integration', () => {
     const listPayload = JSON.parse(listResult.content[0].text);
     assert.equal(listPayload.success, true);
     assert.equal(listPayload.data.length, 2);
+
+    const productsResult = await listProducts(
+      { store_id: '12345' },
+      {
+        request: async () => MOCK_PRODUCTS_RESPONSE
+      }
+    );
+    const productsPayload = JSON.parse(productsResult.content[0].text);
+    assert.equal(productsPayload.success, true);
+    assert.equal(productsPayload.data.length, 1);
+    assert.equal(productsPayload.data[0].link, 'https://www.channel47.com/products/sku-1');
 
     const queryResult = await query(
       { entity: 'campaigns' },
@@ -145,4 +158,3 @@ describe('tool integration', () => {
     assert.equal(mutatePayload.metadata.dryRun, false);
   });
 });
-

--- a/bing-ads/test/list-products.test.js
+++ b/bing-ads/test/list-products.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.BING_ADS_ACCOUNT_ID = '123123123';
+  process.env.BING_ADS_CUSTOMER_ID = '456456456';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('listProducts', () => {
+  test('requires store_id', async () => {
+    const { listProducts } = await import('../server/tools/list-products.js');
+
+    await assert.rejects(
+      () => listProducts({}, { request: async () => ({ resources: [] }) }),
+      /store_id/
+    );
+  });
+
+  test('uses default max_results and normalizes product data', async () => {
+    const { listProducts } = await import('../server/tools/list-products.js');
+    let captured = null;
+
+    const result = await listProducts(
+      { store_id: '12345' },
+      {
+        request: async (url, body, options) => {
+          captured = { url, body, options };
+          return {
+            resources: [
+              {
+                id: 'online:en:US:sku-1',
+                offerId: 'sku-1',
+                title: 'Blue Shirt',
+                link: 'https://example.com/products/sku-1',
+                price: { value: '19.99', currency: 'USD' },
+                salePrice: { value: '14.99', currency: 'USD' },
+                availability: 'in stock',
+                imageLink: 'https://example.com/images/sku-1.jpg',
+                brand: 'Channel47',
+                customLabel0: 'sale',
+                customLabel2: 'spring',
+                mobileLink: 'https://m.example.com/products/sku-1',
+                adwordsRedirect: 'https://redirect.example.com/sku-1',
+                expirationDate: '2026-03-01T00:00:00Z'
+              }
+            ],
+            nextPageToken: 'next-page-token'
+          };
+        }
+      }
+    );
+
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(captured.url.endsWith('/12345/products?max-results=250'), true);
+    assert.equal(captured.body, undefined);
+    assert.equal(captured.options.method, 'GET');
+    assert.equal(captured.options.includeContextHeaders, false);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data[0].offer_id, 'sku-1');
+    assert.equal(payload.data[0].link, 'https://example.com/products/sku-1');
+    assert.deepEqual(payload.data[0].custom_labels, ['sale', 'spring']);
+    assert.equal(payload.metadata.nextPageToken, 'next-page-token');
+    assert.equal(payload.metadata.storeId, '12345');
+  });
+
+  test('supports start_token and custom max_results', async () => {
+    const { listProducts } = await import('../server/tools/list-products.js');
+    let capturedUrl = null;
+
+    await listProducts(
+      { store_id: '12345', max_results: 100, start_token: 'abc123' },
+      {
+        request: async (url) => {
+          capturedUrl = url;
+          return { resources: [] };
+        }
+      }
+    );
+
+    assert.equal(
+      capturedUrl,
+      'https://content.api.bingads.microsoft.com/shopping/v9.1/bmc/12345/products?max-results=100&start-token=abc123'
+    );
+  });
+
+  test('validates max_results range', async () => {
+    const { listProducts } = await import('../server/tools/list-products.js');
+
+    await assert.rejects(
+      () => listProducts({ store_id: '12345', max_results: 0 }, { request: async () => ({ resources: [] }) }),
+      /Invalid max_results/
+    );
+  });
+});

--- a/bing-ads/test/query-campaigns.test.js
+++ b/bing-ads/test/query-campaigns.test.js
@@ -23,6 +23,7 @@ describe('query', () => {
   test('routes campaigns query and normalizes result', async () => {
     const { query } = await import('../server/tools/query-campaigns.js');
     let captured = null;
+    const expectedCampaignTypes = 'Search Shopping DynamicSearchAds Audience Hotel PerformanceMax App';
 
     const result = await query(
       { entity: 'campaigns' },
@@ -37,7 +38,7 @@ describe('query', () => {
     const payload = JSON.parse(result.content[0].text);
     assert.equal(captured.url.endsWith('/Campaigns/QueryByAccountId'), true);
     assert.equal(captured.body.AccountId, '123123123');
-    assert.equal(captured.body.CampaignType, undefined);
+    assert.equal(captured.body.CampaignType, expectedCampaignTypes);
     assert.equal(payload.data[0].id, '333333333');
     assert.equal(payload.data[0].bidding_scheme_type, 'EnhancedCpcBiddingScheme');
   });


### PR DESCRIPTION
## Summary
- fix `query` campaigns default behavior by always sending all supported campaign types when `campaign_type` is omitted (`Search Shopping DynamicSearchAds Audience Hotel PerformanceMax App`)
- add Merchant Center Content API support via a new `list_products` tool (read-only) with pagination (`max_results`, `start_token`) and normalized product fields
- add HTTP support for Content API auth/header differences (`AuthenticationToken`) and document new behavior in README and API reference

## Testing
- `npm test --workspace @channel47/bing-ads-mcp`

## Issues
Closes #4
Closes #5
