### PR TITLE
feat(meta-ads): Meta Ads MCP server

### DIFF
--- a/meta-ads/.gitignore
+++ b/meta-ads/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+.DS_Store
+coverage/

--- a/meta-ads/LICENSE
+++ b/meta-ads/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Channel 47
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meta-ads/README.md
+++ b/meta-ads/README.md
@@ -1,0 +1,130 @@
+# @channel47/meta-ads-mcp
+
+MCP server for Meta Ads (Facebook + Instagram) using the Graph API (`v25.0`).
+
+This server exposes three tools expected by Channel47 Meta workflows:
+
+- `list_accounts`
+- `query`
+- `mutate`
+
+## Installation
+
+### Standalone
+
+```bash
+npx @channel47/meta-ads-mcp@latest
+```
+
+### Monorepo Development
+
+```bash
+cd mcps
+npm install
+npm run test
+```
+
+## Configuration
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `META_ADS_ACCESS_TOKEN` | Meta Graph API access token (long-lived user token or system user token) |
+
+### Optional
+
+| Variable | Description |
+|----------|-------------|
+| `META_ADS_ACCOUNT_ID` | Default ad account ID used when `account_id` is omitted |
+| `META_ADS_READ_ONLY` | Set to `true` to disable live mutations |
+
+## Tool Reference
+
+### `list_accounts`
+
+List accessible ad accounts from `GET /me/adaccounts`.
+
+**Params:**
+- `status` (optional): status filter (`ACTIVE`, `DISABLED`, etc.)
+
+**Notes:**
+- Account IDs are normalized without `act_` prefix
+- Includes raw `account_status` and mapped status text
+
+### `query`
+
+Structured query wrapper for Meta Graph API entities:
+
+- `campaigns`
+- `adsets`
+- `ads`
+- `insights`
+- `audiences`
+- `creatives`
+
+**Core params:**
+- `entity` (required)
+- `account_id` (optional if `META_ADS_ACCOUNT_ID` exists)
+- `fields`, `filters`, `sort`, `limit`
+
+**Insights params:**
+- `date_range`: preset (`today`, `yesterday`, `last_7d`, `last_30d`) or `{ since, until }`
+- `level`: `campaign`, `adset`, or `ad`
+- `time_increment`: `1`, `7`, `monthly`, etc.
+
+### `mutate`
+
+Mutation tool with dry-run safety by default.
+
+**Operation format:**
+
+```json
+{
+  "entity": "campaign",
+  "action": "update",
+  "id": "123456789",
+  "params": {
+    "daily_budget": "5000"
+  }
+}
+```
+
+**Supported entities:**
+- `campaign`
+- `adset`
+- `ad`
+- `audience`
+
+**Supported actions:**
+- `create`
+- `update`
+- `pause`
+- `enable`
+- `delete`
+
+**Top-level params:**
+- `operations` (required)
+- `dry_run` (default `true`)
+- `partial_failure` (default `true`)
+
+## Behavior Notes
+
+- Auth is sent as Graph query param: `access_token`
+- API retries once on:
+  - `401 Unauthorized`
+  - HTTP `429`
+  - Graph error codes `17` and `32`
+- Budgets are returned in minor currency units (example: `5000` means `$50.00` USD)
+
+## Development Commands
+
+```bash
+cd meta-ads
+npm test
+node server/index.js
+```
+
+## License
+
+MIT

--- a/meta-ads/package.json
+++ b/meta-ads/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@channel47/meta-ads-mcp",
+  "version": "1.0.0",
+  "description": "Meta Ads MCP Server - Query and mutate Meta/Facebook/Instagram ads data via Graph API",
+  "main": "server/index.js",
+  "bin": {
+    "meta-ads-mcp": "server/index.js"
+  },
+  "type": "module",
+  "files": [
+    "server/**/*.js",
+    "server/**/*.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "node --test *.test.js test/*.test.js",
+    "prepublishOnly": "npm test"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "meta-ads",
+    "facebook-ads",
+    "instagram-ads",
+    "analytics",
+    "advertising",
+    "claude"
+  ],
+  "author": "Channel47",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/channel47/mcps.git",
+    "directory": "meta-ads"
+  },
+  "bugs": {
+    "url": "https://github.com/channel47/mcps/issues"
+  },
+  "homepage": "https://github.com/channel47/mcps/tree/main/meta-ads#readme",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/meta-ads/server/auth.js
+++ b/meta-ads/server/auth.js
@@ -1,0 +1,29 @@
+const REQUIRED_ENV_VARS = ['META_ADS_ACCESS_TOKEN'];
+
+let cachedAccessToken = null;
+
+export function validateEnvironment() {
+  const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]);
+  return {
+    valid: missing.length === 0,
+    missing
+  };
+}
+
+export async function getAccessToken() {
+  if (cachedAccessToken) {
+    return cachedAccessToken;
+  }
+
+  const { valid, missing } = validateEnvironment();
+  if (!valid) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+
+  cachedAccessToken = String(process.env.META_ADS_ACCESS_TOKEN);
+  return cachedAccessToken;
+}
+
+export function clearAuthCacheForTests() {
+  cachedAccessToken = null;
+}

--- a/meta-ads/server/http.js
+++ b/meta-ads/server/http.js
@@ -1,0 +1,129 @@
+import { clearAuthCacheForTests, getAccessToken } from './auth.js';
+
+export const META_BASE_URL = 'https://graph.facebook.com/v25.0';
+const RATE_LIMIT_ERROR_CODES = new Set([17, 32]);
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizePath(path) {
+  if (!path) {
+    throw new Error('API path is required');
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function buildUrl(path, params = {}, token) {
+  const url = new URL(`${META_BASE_URL}${normalizePath(path)}`);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+
+  url.searchParams.set('access_token', token);
+  return url;
+}
+
+async function parseResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function extractErrorCode(payload) {
+  return Number(payload?.error?.code || 0);
+}
+
+function extractErrorMessage(payload) {
+  if (payload?.error?.message) {
+    return payload.error.message;
+  }
+
+  if (payload?.message) {
+    return payload.message;
+  }
+
+  if (typeof payload === 'string' && payload) {
+    return payload;
+  }
+
+  return 'Unknown Meta Ads API error';
+}
+
+export async function metaRequest(
+  path,
+  params = {},
+  {
+    method = 'GET',
+    body,
+    retryUnauthorized = true,
+    retryThrottled = true,
+    sleep: sleepFn = sleep
+  } = {}
+) {
+  const token = await getAccessToken();
+  const url = buildUrl(path, params, token);
+
+  const requestOptions = {
+    method,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  };
+
+  if (body !== undefined && body !== null) {
+    requestOptions.body = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+
+  const response = await fetch(url, requestOptions);
+  const payload = await parseResponse(response);
+
+  if (response.ok) {
+    return payload;
+  }
+
+  if (response.status === 401 && retryUnauthorized) {
+    clearAuthCacheForTests();
+
+    return metaRequest(path, params, {
+      method,
+      body,
+      retryUnauthorized: false,
+      retryThrottled,
+      sleep: sleepFn
+    });
+  }
+
+  const errorCode = extractErrorCode(payload);
+  const isRateLimited = response.status === 429 || RATE_LIMIT_ERROR_CODES.has(errorCode);
+  if (isRateLimited && retryThrottled) {
+    await sleepFn(60_000);
+
+    return metaRequest(path, params, {
+      method,
+      body,
+      retryUnauthorized,
+      retryThrottled: false,
+      sleep: sleepFn
+    });
+  }
+
+  const message = extractErrorMessage(payload);
+  throw new Error(`Meta Ads API request failed (${response.status}): ${message}`);
+}

--- a/meta-ads/server/index.js
+++ b/meta-ads/server/index.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { validateEnvironment } from './auth.js';
+import { listAccounts } from './tools/list-accounts.js';
+import { query } from './tools/query.js';
+import { mutate } from './tools/mutate.js';
+import { getPromptsList, renderPrompt } from './prompts/templates.js';
+import { getResourcesList, readResource } from './resources/index.js';
+
+const SERVER_NAME = 'meta-ads-mcp';
+const SERVER_VERSION = '1.0.0';
+const READ_ONLY = process.env.META_ADS_READ_ONLY === 'true';
+
+const ALL_TOOLS = [
+  {
+    name: 'list_accounts',
+    description: 'List all accessible Meta ad accounts for the authenticated token.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          description: 'Optional account status filter (e.g. ACTIVE, DISABLED)'
+        }
+      }
+    }
+  },
+  {
+    name: 'query',
+    description: 'Query campaigns, adsets, ads, insights, audiences, or creatives from Meta Graph API.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        account_id: {
+          type: 'string',
+          description: 'Meta account ID. Supports either 123... or act_123...'
+        },
+        entity: {
+          type: 'string',
+          enum: ['campaigns', 'adsets', 'ads', 'insights', 'audiences', 'creatives'],
+          description: 'Entity type to query'
+        },
+        fields: {
+          anyOf: [
+            { type: 'string' },
+            {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          ],
+          description: 'Optional fields selection. Defaults to entity-specific presets.'
+        },
+        filters: {
+          type: 'array',
+          items: { type: 'object' },
+          description: 'Optional structured Graph filtering clauses'
+        },
+        date_range: {
+          anyOf: [{ type: 'string' }, { type: 'object' }],
+          description: 'Insights-only date range preset or { since, until } object'
+        },
+        level: {
+          type: 'string',
+          description: 'Insights-only breakdown level (campaign, adset, ad)'
+        },
+        time_increment: {
+          anyOf: [{ type: 'string' }, { type: 'integer' }],
+          description: 'Insights-only increment (1, 7, monthly, etc.)'
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 1000,
+          description: 'Maximum rows to return (default: 100, max: 1000)'
+        },
+        sort: {
+          type: 'string',
+          description: 'Optional sort expression'
+        }
+      },
+      required: ['entity']
+    }
+  },
+  {
+    name: 'mutate',
+    description: 'Execute create/update/pause/enable/delete operations for campaign, adset, ad, and audience entities. dry_run defaults to true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        account_id: {
+          type: 'string',
+          description: 'Meta account ID. Supports either 123... or act_123...'
+        },
+        operations: {
+          type: 'array',
+          description: 'Array of operation objects: { entity, action, id?, params? }',
+          items: {
+            type: 'object'
+          }
+        },
+        dry_run: {
+          type: 'boolean',
+          description: 'Validate and preview only (default: true)',
+          default: true
+        },
+        partial_failure: {
+          type: 'boolean',
+          description: 'Continue executing later operations when one fails (default: true)',
+          default: true
+        }
+      },
+      required: ['operations']
+    }
+  }
+];
+
+const TOOLS = READ_ONLY ? ALL_TOOLS.filter((tool) => tool.name !== 'mutate') : ALL_TOOLS;
+
+const envStatus = validateEnvironment();
+if (!envStatus.valid) {
+  console.error(`Missing required environment variables: ${envStatus.missing.join(', ')}`);
+  process.exit(1);
+}
+
+if (READ_ONLY) {
+  console.error('Read-only mode enabled — mutate tool disabled');
+}
+
+const server = new Server(
+  {
+    name: SERVER_NAME,
+    version: SERVER_VERSION
+  },
+  {
+    capabilities: {
+      tools: {},
+      prompts: {},
+      resources: {}
+    }
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: params } = request.params;
+
+  if (name === 'list_accounts') {
+    return listAccounts(params);
+  }
+
+  if (name === 'query') {
+    return query(params);
+  }
+
+  if (name === 'mutate') {
+    if (READ_ONLY) {
+      throw new Error('mutate is disabled in read-only mode (META_ADS_READ_ONLY=true)');
+    }
+    return mutate(params);
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+});
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: getPromptsList() }));
+server.setRequestHandler(GetPromptRequestSchema, async (request) => (
+  renderPrompt(request.params.name, request.params.arguments || {})
+));
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: getResourcesList() }));
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => readResource(request.params.uri));
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`${SERVER_NAME} v${SERVER_VERSION} started`);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/meta-ads/server/prompts/templates.js
+++ b/meta-ads/server/prompts/templates.js
@@ -1,0 +1,119 @@
+export const PROMPT_TEMPLATES = {
+  creative_fatigue_check: {
+    name: 'creative_fatigue_check',
+    description: 'Check for ad creative fatigue signals and propose refresh priorities',
+    arguments: [
+      {
+        name: 'account_id',
+        description: 'Meta ad account ID (without act_ prefix)',
+        required: true
+      },
+      {
+        name: 'date_range',
+        description: 'Insights date preset (last_7d, last_30d, today, yesterday)',
+        required: false,
+        default: 'last_7d'
+      }
+    ],
+    template: `Run a creative fatigue analysis for Meta account {{account_id}} using {{date_range}} data:
+
+1. Pull ad-level insights (spend, impressions, clicks, ctr, frequency).
+2. Flag ads with high frequency and declining CTR.
+3. Group fatigued ads by campaign/ad set.
+4. Identify top creatives to refresh first by wasted spend.
+5. Return prioritized creative refresh recommendations with rationale.`,
+    requiredTools: ['query']
+  },
+  audience_overlap_check: {
+    name: 'audience_overlap_check',
+    description: 'Review audience definitions and identify overlap/conflict risk',
+    arguments: [
+      {
+        name: 'account_id',
+        description: 'Meta ad account ID (without act_ prefix)',
+        required: true
+      }
+    ],
+    template: `Run an audience overlap check for Meta account {{account_id}}:
+
+1. Pull active ad sets with targeting details.
+2. Pull custom audiences in the account.
+3. Identify segments likely competing in auction (same geo/age/interests/lookalikes).
+4. Flag exclusions that are missing and likely to cause overlap.
+5. Return concrete audience restructuring suggestions.`,
+    requiredTools: ['query']
+  },
+  spend_pacing_check: {
+    name: 'spend_pacing_check',
+    description: 'Check pacing against recent spend and budget signals',
+    arguments: [
+      {
+        name: 'account_id',
+        description: 'Meta ad account ID (without act_ prefix)',
+        required: true
+      },
+      {
+        name: 'date_range',
+        description: 'Insights date preset',
+        required: false,
+        default: 'last_7d'
+      }
+    ],
+    template: `Run a spend pacing check for Meta account {{account_id}} over {{date_range}}:
+
+1. Pull campaign-level insights and budget fields.
+2. Compare current spend velocity to available daily/lifetime budgets.
+3. Flag campaigns underpacing and overpacing.
+4. Highlight campaigns spending with weak conversion signals.
+5. Return top pacing issues and recommended budget actions.`,
+    requiredTools: ['query']
+  }
+};
+
+export function getPromptDefinition(name) {
+  return PROMPT_TEMPLATES[name] || null;
+}
+
+export function getPromptsList() {
+  return Object.values(PROMPT_TEMPLATES).map((prompt) => ({
+    name: prompt.name,
+    description: prompt.description,
+    arguments: prompt.arguments
+  }));
+}
+
+export function renderPrompt(name, args = {}) {
+  const template = PROMPT_TEMPLATES[name];
+  if (!template) {
+    throw new Error(`Unknown prompt: ${name}. Available prompts: ${Object.keys(PROMPT_TEMPLATES).join(', ')}`);
+  }
+
+  const missing = template.arguments
+    .filter((argument) => argument.required && !args[argument.name])
+    .map((argument) => argument.name);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required arguments for prompt "${name}": ${missing.join(', ')}`);
+  }
+
+  let text = template.template;
+
+  for (const argument of template.arguments) {
+    const value = args[argument.name] ?? argument.default;
+    if (value !== undefined) {
+      text = text.replace(new RegExp(`\\{\\{${argument.name}\\}\\}`, 'g'), String(value));
+    }
+  }
+
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text
+        }
+      }
+    ]
+  };
+}

--- a/meta-ads/server/resources/graph-api-reference.md
+++ b/meta-ads/server/resources/graph-api-reference.md
@@ -1,0 +1,78 @@
+# Meta Ads Graph API Quick Reference
+
+## Base URL
+
+`https://graph.facebook.com/v25.0`
+
+## Authentication
+
+- Auth is provided via query param: `access_token=<TOKEN>`
+- This server reads token from `META_ADS_ACCESS_TOKEN`
+- No token refresh flow in v1 (supports long-lived user tokens and system user tokens)
+
+## Account Discovery
+
+- List accounts: `GET /me/adaccounts`
+- Suggested fields:
+  - `id,name,account_status,currency,timezone_name,business{name}`
+
+## Query Endpoints (by Account)
+
+Use normalized account IDs in tools (`1234567890`) and API paths with `act_` prefix:
+
+- Campaigns: `GET /act_<ACCOUNT_ID>/campaigns`
+- Ad sets: `GET /act_<ACCOUNT_ID>/adsets`
+- Ads: `GET /act_<ACCOUNT_ID>/ads`
+- Insights: `GET /act_<ACCOUNT_ID>/insights`
+- Audiences: `GET /act_<ACCOUNT_ID>/customaudiences`
+- Creatives: `GET /act_<ACCOUNT_ID>/adcreatives`
+
+Useful query params:
+
+- `fields`: comma-separated field list
+- `limit`: up to 1000
+- `after`: pagination cursor
+- `filtering`: JSON-encoded filter array
+- `sort`: sort expression
+
+Insights-only params:
+
+- `time_range`: JSON object (`{ "since": "YYYY-MM-DD", "until": "YYYY-MM-DD" }`)
+- `level`: `campaign` | `adset` | `ad`
+- `time_increment`: `1`, `7`, `monthly`, etc.
+
+## Mutations
+
+Typical write patterns:
+
+- Create: `POST /act_<ACCOUNT_ID>/<entity_collection>`
+- Update: `POST /<OBJECT_ID>`
+- Pause/Enable: `POST /<OBJECT_ID>` with `status=PAUSED` or `status=ACTIVE`
+- Delete: `DELETE /<OBJECT_ID>`
+
+Supported entity collections in this server:
+
+- Campaign: `campaigns`
+- Ad set: `adsets`
+- Ad: `ads`
+- Audience: `customaudiences`
+
+## Error Handling
+
+Retry strategy in this server:
+
+- Retry once on `401 Unauthorized`
+- Retry once on throttling:
+  - HTTP `429`
+  - Graph error codes `17` or `32`
+
+Error message extraction priority:
+
+1. `payload.error.message`
+2. `payload.message`
+3. Fallback generic message
+
+## Notes
+
+- Budget values are returned in minor currency units (e.g., `5000` => `$50.00` USD)
+- Graph API version is pinned in code (`v25.0`) for predictable behavior

--- a/meta-ads/server/resources/index.js
+++ b/meta-ads/server/resources/index.js
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const RESOURCES = [
+  {
+    uri: 'metaads://reference',
+    name: 'Meta Ads Graph API Reference',
+    description: 'Core Graph API endpoints, query parameters, and error handling notes for Meta Ads workflows',
+    mimeType: 'text/markdown'
+  }
+];
+
+const RESOURCE_FILE_MAP = {
+  'metaads://reference': 'graph-api-reference.md'
+};
+
+export function getResourcesList() {
+  return RESOURCES;
+}
+
+export function readResource(uri) {
+  const filename = RESOURCE_FILE_MAP[uri];
+  if (!filename) {
+    throw new Error(`Unknown resource: ${uri}. Available: ${Object.keys(RESOURCE_FILE_MAP).join(', ')}`);
+  }
+
+  const filePath = join(__dirname, filename);
+  const content = readFileSync(filePath, 'utf8');
+
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'text/markdown',
+        text: content
+      }
+    ]
+  };
+}

--- a/meta-ads/server/tools/list-accounts.js
+++ b/meta-ads/server/tools/list-accounts.js
@@ -1,0 +1,57 @@
+import { metaRequest } from '../http.js';
+import { formatError, formatSuccess } from '../utils/response-format.js';
+import { normalizeAccountId } from '../utils/validation.js';
+
+const ACCOUNT_STATUS_MAP = {
+  1: 'ACTIVE',
+  2: 'DISABLED',
+  3: 'UNSETTLED',
+  7: 'PENDING_REVIEW',
+  8: 'PENDING_CLOSURE',
+  9: 'IN_GRACE_PERIOD',
+  100: 'PENDING_RISK_REVIEW'
+};
+
+function normalizeStatus(code) {
+  return ACCOUNT_STATUS_MAP[Number(code)] || 'UNKNOWN';
+}
+
+function mapAccount(account) {
+  return {
+    id: normalizeAccountId(account?.id),
+    name: account?.name || '',
+    account_status: Number(account?.account_status || 0),
+    status: normalizeStatus(account?.account_status),
+    currency: account?.currency || null,
+    timezone_name: account?.timezone_name || null,
+    business_name: account?.business?.name || null
+  };
+}
+
+export async function listAccounts(params = {}, dependencies = {}) {
+  const request = dependencies.request || metaRequest;
+
+  try {
+    const response = await request('/me/adaccounts', {
+      fields: 'id,name,account_status,currency,timezone_name,business{name}'
+    });
+
+    const allAccounts = (response?.data || []).map(mapAccount);
+    const statusFilter = params.status ? String(params.status).toUpperCase() : null;
+
+    const filteredAccounts = statusFilter
+      ? allAccounts.filter((account) => account.status === statusFilter)
+      : allAccounts;
+
+    return formatSuccess({
+      summary: `Found ${filteredAccounts.length} accessible Meta ad account${filteredAccounts.length === 1 ? '' : 's'}`,
+      data: filteredAccounts,
+      metadata: {
+        totalAccounts: filteredAccounts.length,
+        appliedStatusFilter: statusFilter
+      }
+    });
+  } catch (error) {
+    return formatError(error);
+  }
+}

--- a/meta-ads/server/tools/mutate.js
+++ b/meta-ads/server/tools/mutate.js
@@ -1,0 +1,103 @@
+import { metaRequest } from '../http.js';
+import { formatError, formatSuccess } from '../utils/response-format.js';
+import { getAccountId } from '../utils/validation.js';
+import {
+  buildApiRequest,
+  buildRequestPreview,
+  validateOperations
+} from '../utils/mutate-operations.js';
+
+export async function mutate(params = {}, dependencies = {}) {
+  const request = dependencies.request || metaRequest;
+
+  try {
+    const operations = params.operations;
+    const accountId = getAccountId(params);
+    const partialFailure = params.partial_failure === undefined ? true : Boolean(params.partial_failure);
+    const dryRun = params.dry_run === undefined ? true : Boolean(params.dry_run);
+
+    const validationErrors = validateOperations(operations);
+    if (validationErrors.length > 0) {
+      const errorMessage = validationErrors.map((issue) => `[${issue.index}] ${issue.message}`).join('; ');
+      throw new Error(`Invalid operations: ${errorMessage}`);
+    }
+
+    if (dryRun) {
+      const preview = buildRequestPreview(operations, accountId);
+      return formatSuccess({
+        summary: `Dry run: ${operations.length} operation(s) validated. ${preview.requests.length} request(s) would be sent. Client-side validation only — no changes applied.`,
+        data: preview.requests,
+        metadata: {
+          dryRun: true,
+          operationCount: operations.length,
+          apiCallCount: preview.requests.length,
+          accountId
+        }
+      });
+    }
+
+    if (process.env.META_ADS_READ_ONLY === 'true') {
+      throw new Error('mutate is disabled in read-only mode (META_ADS_READ_ONLY=true)');
+    }
+
+    const results = [];
+    let succeeded = 0;
+    let failed = 0;
+
+    for (let index = 0; index < operations.length; index += 1) {
+      const operation = operations[index];
+      const apiRequest = buildApiRequest(operation, accountId);
+
+      try {
+        const response = await request(apiRequest.path, apiRequest.params, {
+          method: apiRequest.method
+        });
+
+        const resolvedId = response?.id || operation.id || null;
+        results.push({
+          index,
+          entity: operation.entity,
+          action: operation.action,
+          success: true,
+          id: resolvedId,
+          response
+        });
+        succeeded += 1;
+      } catch (error) {
+        results.push({
+          index,
+          entity: operation.entity,
+          action: operation.action,
+          success: false,
+          error: {
+            message: error.message
+          }
+        });
+        failed += 1;
+
+        if (!partialFailure) {
+          break;
+        }
+      }
+    }
+
+    if (succeeded === 0 && failed > 0) {
+      const firstError = results.find((entry) => !entry.success)?.error?.message || 'Unknown';
+      throw new Error(`All ${failed} operation(s) failed. First error: ${firstError}`);
+    }
+
+    return formatSuccess({
+      summary: `Executed ${results.length} operation(s): ${succeeded} succeeded, ${failed} failed`,
+      data: results,
+      metadata: {
+        dryRun: false,
+        operationCount: results.length,
+        succeeded,
+        failed,
+        accountId
+      }
+    });
+  } catch (error) {
+    return formatError(error);
+  }
+}

--- a/meta-ads/server/tools/query.js
+++ b/meta-ads/server/tools/query.js
@@ -1,0 +1,133 @@
+import { metaRequest } from '../http.js';
+import { formatError, formatSuccess } from '../utils/response-format.js';
+import {
+  ENTITY_FIELDS,
+  SUPPORTED_ENTITIES,
+  resolveInsightsDateRange
+} from '../utils/field-defaults.js';
+import { getAccountId, validateEnum } from '../utils/validation.js';
+
+const ENTITY_PATHS = {
+  campaigns: 'campaigns',
+  adsets: 'adsets',
+  ads: 'ads',
+  insights: 'insights',
+  audiences: 'customaudiences',
+  creatives: 'adcreatives'
+};
+
+function getRequestedFields(entity, fields) {
+  if (!fields) {
+    return ENTITY_FIELDS[entity].join(',');
+  }
+
+  if (Array.isArray(fields)) {
+    return fields.join(',');
+  }
+
+  return String(fields);
+}
+
+function getRequestedLimit(limitValue) {
+  if (limitValue === undefined || limitValue === null || limitValue === '') {
+    return 100;
+  }
+
+  const parsed = Number(limitValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 100;
+  }
+
+  return Math.min(Math.floor(parsed), 1000);
+}
+
+function buildBaseParams(params, entity) {
+  const limit = getRequestedLimit(params.limit);
+  const queryParams = {
+    fields: getRequestedFields(entity, params.fields),
+    limit: String(limit)
+  };
+
+  if (Array.isArray(params.filters) && params.filters.length > 0) {
+    queryParams.filtering = JSON.stringify(params.filters);
+  }
+
+  if (params.sort) {
+    queryParams.sort = String(params.sort);
+  }
+
+  if (entity === 'insights') {
+    const timeRange = resolveInsightsDateRange(params.date_range);
+    queryParams.time_range = JSON.stringify(timeRange);
+
+    if (params.level) {
+      queryParams.level = String(params.level);
+    }
+
+    if (params.time_increment !== undefined && params.time_increment !== null) {
+      queryParams.time_increment = String(params.time_increment);
+    }
+  }
+
+  return queryParams;
+}
+
+async function fetchAllPages(path, initialParams, requestedLimit, request) {
+  let after = null;
+  const results = [];
+
+  while (results.length < requestedLimit) {
+    const pageParams = {
+      ...initialParams,
+      limit: String(Math.min(requestedLimit, 1000))
+    };
+
+    if (after) {
+      pageParams.after = after;
+    }
+
+    const response = await request(path, pageParams);
+    const data = Array.isArray(response?.data) ? response.data : [];
+    results.push(...data);
+
+    if (results.length >= requestedLimit) {
+      break;
+    }
+
+    after = response?.paging?.cursors?.after;
+    if (!after) {
+      break;
+    }
+  }
+
+  return results.slice(0, requestedLimit);
+}
+
+export async function query(params = {}, dependencies = {}) {
+  const request = dependencies.request || metaRequest;
+
+  try {
+    validateEnum(params.entity, SUPPORTED_ENTITIES, 'entity');
+
+    const accountId = getAccountId(params);
+    const entity = params.entity;
+    const requestedLimit = getRequestedLimit(params.limit);
+    const path = `/act_${accountId}/${ENTITY_PATHS[entity]}`;
+
+    const queryParams = buildBaseParams(params, entity);
+    const rows = await fetchAllPages(path, queryParams, requestedLimit, request);
+
+    return formatSuccess({
+      summary: `Returned ${rows.length} ${entity} row${rows.length === 1 ? '' : 's'}`,
+      data: rows,
+      metadata: {
+        entity,
+        accountId,
+        limit: requestedLimit,
+        returned: rows.length
+      }
+    });
+  } catch (error) {
+    return formatError(error);
+  }
+}

--- a/meta-ads/server/utils/field-defaults.js
+++ b/meta-ads/server/utils/field-defaults.js
@@ -1,0 +1,122 @@
+export const ENTITY_FIELDS = {
+  campaigns: [
+    'id',
+    'name',
+    'status',
+    'objective',
+    'daily_budget',
+    'lifetime_budget',
+    'buying_type',
+    'bid_strategy',
+    'effective_status'
+  ],
+  adsets: [
+    'id',
+    'name',
+    'status',
+    'campaign_id',
+    'daily_budget',
+    'targeting',
+    'optimization_goal',
+    'billing_event',
+    'effective_status'
+  ],
+  ads: [
+    'id',
+    'name',
+    'status',
+    'adset_id',
+    'creative{id,name,title,body,image_url,video_id}',
+    'effective_status'
+  ],
+  insights: [
+    'spend',
+    'impressions',
+    'clicks',
+    'ctr',
+    'cpm',
+    'cpc',
+    'conversions',
+    'cost_per_action_type',
+    'frequency',
+    'reach',
+    'actions'
+  ],
+  audiences: [
+    'id',
+    'name',
+    'subtype',
+    'approximate_count',
+    'data_source',
+    'delivery_status'
+  ],
+  creatives: [
+    'id',
+    'name',
+    'title',
+    'body',
+    'image_url',
+    'video_id',
+    'object_story_spec'
+  ]
+};
+
+export const SUPPORTED_ENTITIES = Object.keys(ENTITY_FIELDS);
+
+export const INSIGHTS_PRESETS = {
+  today: { sinceOffsetDays: 0, untilOffsetDays: 0 },
+  yesterday: { sinceOffsetDays: -1, untilOffsetDays: -1 },
+  last_7d: { sinceOffsetDays: -6, untilOffsetDays: 0 },
+  last_30d: { sinceOffsetDays: -29, untilOffsetDays: 0 }
+};
+
+function toIsoDateUtc(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function offsetUtcDays(date, days) {
+  const copy = new Date(date);
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function validateDate(value, label) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Invalid ${label} date format: ${value}. Expected YYYY-MM-DD`);
+  }
+}
+
+export function resolveInsightsDateRange(dateRange, now = new Date()) {
+  if (!dateRange) {
+    return resolveInsightsDateRange('last_7d', now);
+  }
+
+  if (typeof dateRange === 'string') {
+    const presetKey = dateRange.toLowerCase();
+    const preset = INSIGHTS_PRESETS[presetKey];
+    if (!preset) {
+      throw new Error(`Invalid date_range preset: ${dateRange}. Allowed: ${Object.keys(INSIGHTS_PRESETS).join(', ')}`);
+    }
+
+    return {
+      since: toIsoDateUtc(offsetUtcDays(now, preset.sinceOffsetDays)),
+      until: toIsoDateUtc(offsetUtcDays(now, preset.untilOffsetDays))
+    };
+  }
+
+  if (typeof dateRange === 'object') {
+    const since = dateRange.since;
+    const until = dateRange.until;
+
+    if (!since || !until) {
+      throw new Error('date_range object must include both since and until');
+    }
+
+    validateDate(since, 'since');
+    validateDate(until, 'until');
+
+    return { since, until };
+  }
+
+  throw new Error('date_range must be a preset string or { since, until } object');
+}

--- a/meta-ads/server/utils/mutate-operations.js
+++ b/meta-ads/server/utils/mutate-operations.js
@@ -1,0 +1,134 @@
+import { validateArray, withActPrefix } from './validation.js';
+
+export const SUPPORTED_MUTATE_ENTITIES = ['campaign', 'adset', 'ad', 'audience'];
+export const SUPPORTED_MUTATE_ACTIONS = ['create', 'update', 'pause', 'enable', 'delete'];
+
+const CREATE_ENTITY_PATHS = {
+  campaign: 'campaigns',
+  adset: 'adsets',
+  ad: 'ads',
+  audience: 'customaudiences'
+};
+
+function validateOperationShape(op, index) {
+  if (!op || typeof op !== 'object' || Array.isArray(op)) {
+    return { index, message: 'Operation must be an object' };
+  }
+
+  if (!op.entity) {
+    return { index, message: 'Missing required field: entity' };
+  }
+
+  if (!SUPPORTED_MUTATE_ENTITIES.includes(op.entity)) {
+    return {
+      index,
+      message: `Unsupported entity: ${op.entity}. Supported: ${SUPPORTED_MUTATE_ENTITIES.join(', ')}`
+    };
+  }
+
+  if (!op.action) {
+    return { index, message: 'Missing required field: action' };
+  }
+
+  if (!SUPPORTED_MUTATE_ACTIONS.includes(op.action)) {
+    return {
+      index,
+      message: `Unsupported action: ${op.action}. Supported: ${SUPPORTED_MUTATE_ACTIONS.join(', ')}`
+    };
+  }
+
+  if ((op.action === 'create' || op.action === 'update') && (!op.params || typeof op.params !== 'object' || Array.isArray(op.params))) {
+    return {
+      index,
+      message: `${op.action} requires params object`
+    };
+  }
+
+  if (op.action !== 'create' && !op.id) {
+    return {
+      index,
+      message: `${op.action} requires id`
+    };
+  }
+
+  return null;
+}
+
+export function validateOperations(operations) {
+  validateArray(operations, 'operations');
+
+  const errors = [];
+  for (let index = 0; index < operations.length; index += 1) {
+    const issue = validateOperationShape(operations[index], index);
+    if (issue) {
+      errors.push(issue);
+    }
+  }
+
+  return errors;
+}
+
+export function buildApiRequest(operation, accountId) {
+  const action = operation.action;
+
+  if (action === 'create') {
+    const parentPath = CREATE_ENTITY_PATHS[operation.entity];
+    return {
+      method: 'POST',
+      path: `/${withActPrefix(accountId)}/${parentPath}`,
+      params: { ...operation.params }
+    };
+  }
+
+  if (action === 'delete') {
+    return {
+      method: 'DELETE',
+      path: `/${operation.id}`,
+      params: {}
+    };
+  }
+
+  if (action === 'pause') {
+    return {
+      method: 'POST',
+      path: `/${operation.id}`,
+      params: {
+        status: 'PAUSED',
+        ...(operation.params || {})
+      }
+    };
+  }
+
+  if (action === 'enable') {
+    return {
+      method: 'POST',
+      path: `/${operation.id}`,
+      params: {
+        status: 'ACTIVE',
+        ...(operation.params || {})
+      }
+    };
+  }
+
+  return {
+    method: 'POST',
+    path: `/${operation.id}`,
+    params: { ...(operation.params || {}) }
+  };
+}
+
+export function buildRequestPreview(operations, accountId) {
+  return {
+    requests: operations.map((operation, index) => {
+      const request = buildApiRequest(operation, accountId);
+      return {
+        index,
+        entity: operation.entity,
+        action: operation.action,
+        method: request.method,
+        path: request.path,
+        params: request.params
+      };
+    })
+  };
+}

--- a/meta-ads/server/utils/response-format.js
+++ b/meta-ads/server/utils/response-format.js
@@ -1,0 +1,52 @@
+let SdkMcpError = null;
+let SdkErrorCode = null;
+
+try {
+  const sdkTypes = await import('@modelcontextprotocol/sdk/types.js');
+  SdkMcpError = sdkTypes.McpError;
+  SdkErrorCode = sdkTypes.ErrorCode;
+} catch {
+  // SDK may be absent in minimal test environments.
+}
+
+export function formatSuccess({ summary, data, metadata = {} }) {
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        success: true,
+        summary,
+        data,
+        metadata: {
+          rowCount: Array.isArray(data) ? data.length : undefined,
+          warnings: [],
+          ...metadata
+        }
+      }, null, 2)
+    }]
+  };
+}
+
+function createMcpStyleError(code, message) {
+  if (SdkMcpError && SdkErrorCode && SdkErrorCode[code]) {
+    return new SdkMcpError(SdkErrorCode[code], message);
+  }
+
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+export function formatError(error) {
+  const message = error?.message || String(error) || 'Unknown error';
+
+  if (message.includes('required') || message.includes('Invalid')) {
+    throw createMcpStyleError('InvalidParams', message);
+  }
+
+  if (message.includes('Unauthorized') || message.includes('access token') || message.includes('access_token')) {
+    throw createMcpStyleError('InvalidParams', message);
+  }
+
+  throw createMcpStyleError('InternalError', message);
+}

--- a/meta-ads/server/utils/validation.js
+++ b/meta-ads/server/utils/validation.js
@@ -1,0 +1,50 @@
+export function validateRequired(params, fields) {
+  const missing = fields.filter((field) => {
+    const value = params[field];
+    return value === undefined || value === null || value === '';
+  });
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required parameter${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`);
+  }
+}
+
+export function validateEnum(value, allowed, paramName = 'value') {
+  if (!allowed.includes(value)) {
+    throw new Error(`Invalid ${paramName}: ${value}. Allowed values: ${allowed.join(', ')}`);
+  }
+}
+
+export function validateArray(value, paramName = 'value') {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${paramName} must be a non-empty array`);
+  }
+}
+
+export function normalizeAccountId(accountId) {
+  const raw = String(accountId || '').trim();
+  if (!raw) {
+    return '';
+  }
+
+  return raw.startsWith('act_') ? raw.slice(4) : raw;
+}
+
+export function withActPrefix(accountId) {
+  const normalized = normalizeAccountId(accountId);
+  if (!normalized) {
+    return '';
+  }
+
+  return `act_${normalized}`;
+}
+
+export function getAccountId(params = {}, { prefixed = false } = {}) {
+  const accountId = params.account_id || process.env.META_ADS_ACCOUNT_ID;
+  if (!accountId) {
+    throw new Error('account_id parameter or META_ADS_ACCOUNT_ID environment variable required');
+  }
+
+  const normalized = normalizeAccountId(accountId);
+  return prefixed ? withActPrefix(normalized) : normalized;
+}

--- a/meta-ads/test/auth.test.js
+++ b/meta-ads/test/auth.test.js
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function importFresh(modulePath) {
+  return import(`${modulePath}?v=${Date.now()}-${Math.random()}`);
+}
+
+beforeEach(() => {
+  process.env.META_ADS_ACCESS_TOKEN = 'meta-token-1';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('validateEnvironment', () => {
+  test('passes when META_ADS_ACCESS_TOKEN exists', async () => {
+    const { validateEnvironment } = await importFresh('../server/auth.js');
+    const result = validateEnvironment();
+
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.missing, []);
+  });
+
+  test('fails when META_ADS_ACCESS_TOKEN is missing', async () => {
+    delete process.env.META_ADS_ACCESS_TOKEN;
+
+    const { validateEnvironment } = await importFresh('../server/auth.js');
+    const result = validateEnvironment();
+
+    assert.equal(result.valid, false);
+    assert.deepEqual(result.missing, ['META_ADS_ACCESS_TOKEN']);
+  });
+});
+
+describe('getAccessToken', () => {
+  test('returns token from environment', async () => {
+    const { getAccessToken } = await importFresh('../server/auth.js');
+    const token = await getAccessToken();
+
+    assert.equal(token, 'meta-token-1');
+  });
+
+  test('returns cached token until cache is cleared', async () => {
+    const { getAccessToken, clearAuthCacheForTests } = await importFresh('../server/auth.js');
+
+    const first = await getAccessToken();
+    process.env.META_ADS_ACCESS_TOKEN = 'meta-token-2';
+    const second = await getAccessToken();
+
+    clearAuthCacheForTests();
+    const third = await getAccessToken();
+
+    assert.equal(first, 'meta-token-1');
+    assert.equal(second, 'meta-token-1');
+    assert.equal(third, 'meta-token-2');
+  });
+
+  test('throws when token is missing', async () => {
+    delete process.env.META_ADS_ACCESS_TOKEN;
+
+    const { getAccessToken } = await importFresh('../server/auth.js');
+
+    await assert.rejects(
+      () => getAccessToken(),
+      /META_ADS_ACCESS_TOKEN/
+    );
+  });
+});

--- a/meta-ads/test/field-defaults.test.js
+++ b/meta-ads/test/field-defaults.test.js
@@ -1,0 +1,61 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ENTITY_FIELDS,
+  SUPPORTED_ENTITIES,
+  resolveInsightsDateRange
+} from '../server/utils/field-defaults.js';
+
+describe('SUPPORTED_ENTITIES', () => {
+  test('includes all supported query entities', () => {
+    assert.deepEqual(SUPPORTED_ENTITIES, [
+      'campaigns',
+      'adsets',
+      'ads',
+      'insights',
+      'audiences',
+      'creatives'
+    ]);
+  });
+});
+
+describe('ENTITY_FIELDS', () => {
+  test('has default campaign and insights fields', () => {
+    assert.ok(ENTITY_FIELDS.campaigns.includes('objective'));
+    assert.ok(ENTITY_FIELDS.insights.includes('spend'));
+  });
+});
+
+describe('resolveInsightsDateRange', () => {
+  test('resolves last_7d preset', () => {
+    const result = resolveInsightsDateRange('last_7d', new Date('2026-02-28T12:00:00.000Z'));
+    assert.deepEqual(result, {
+      since: '2026-02-22',
+      until: '2026-02-28'
+    });
+  });
+
+  test('resolves yesterday preset', () => {
+    const result = resolveInsightsDateRange('yesterday', new Date('2026-02-28T12:00:00.000Z'));
+    assert.deepEqual(result, {
+      since: '2026-02-27',
+      until: '2026-02-27'
+    });
+  });
+
+  test('passes through explicit date object', () => {
+    const result = resolveInsightsDateRange({ since: '2026-01-01', until: '2026-01-15' });
+    assert.deepEqual(result, {
+      since: '2026-01-01',
+      until: '2026-01-15'
+    });
+  });
+
+  test('throws on unsupported preset', () => {
+    assert.throws(
+      () => resolveInsightsDateRange('last_90d'),
+      /Invalid date_range preset/
+    );
+  });
+});

--- a/meta-ads/test/fixtures.js
+++ b/meta-ads/test/fixtures.js
@@ -1,0 +1,78 @@
+export const MOCK_LIST_ACCOUNTS_RESPONSE = {
+  data: [
+    {
+      id: 'act_1234567890',
+      name: 'Primary Meta Account',
+      account_status: 1,
+      currency: 'USD',
+      timezone_name: 'America/Los_Angeles',
+      business: {
+        name: 'Channel47 LLC'
+      }
+    },
+    {
+      id: 'act_222333444',
+      name: 'Disabled Account',
+      account_status: 2,
+      currency: 'USD',
+      timezone_name: 'America/New_York',
+      business: null
+    }
+  ]
+};
+
+export const MOCK_QUERY_CAMPAIGNS_PAGE_1 = {
+  data: [
+    {
+      id: '1001',
+      name: 'Brand Search',
+      status: 'ACTIVE'
+    },
+    {
+      id: '1002',
+      name: 'Non-Brand Search',
+      status: 'PAUSED'
+    }
+  ],
+  paging: {
+    cursors: {
+      after: 'cursor_page_2'
+    }
+  }
+};
+
+export const MOCK_QUERY_CAMPAIGNS_PAGE_2 = {
+  data: [
+    {
+      id: '1003',
+      name: 'Shopping Prospecting',
+      status: 'ACTIVE'
+    }
+  ],
+  paging: {
+    cursors: {}
+  }
+};
+
+export const MOCK_INSIGHTS_RESPONSE = {
+  data: [
+    {
+      spend: '145.44',
+      impressions: '10000',
+      clicks: '332',
+      ctr: '3.32'
+    }
+  ]
+};
+
+export const MOCK_MUTATE_CREATE_RESPONSE = {
+  id: '99887766'
+};
+
+export const MOCK_MUTATE_UPDATE_RESPONSE = {
+  success: true
+};
+
+export const MOCK_MUTATE_DELETE_RESPONSE = {
+  success: true
+};

--- a/meta-ads/test/http.test.js
+++ b/meta-ads/test/http.test.js
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function importFresh(modulePath) {
+  return import(`${modulePath}?v=${Date.now()}-${Math.random()}`);
+}
+
+function jsonResponse(data, init = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers: {
+      get(name) {
+        if (String(name).toLowerCase() === 'content-type') {
+          return init.contentType ?? 'application/json';
+        }
+        return null;
+      }
+    },
+    async json() {
+      return data;
+    },
+    async text() {
+      return typeof data === 'string' ? data : JSON.stringify(data);
+    }
+  };
+}
+
+beforeEach(() => {
+  process.env.META_ADS_ACCESS_TOKEN = 'meta-token-123';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete global.fetch;
+});
+
+describe('metaRequest', () => {
+  test('builds Graph API URL with query params and access token', async () => {
+    let capturedUrl = null;
+
+    global.fetch = async (url) => {
+      capturedUrl = String(url);
+      return jsonResponse({ data: [] });
+    };
+
+    const { metaRequest } = await importFresh('../server/http.js');
+    await metaRequest('/me/adaccounts', { fields: 'id,name', limit: 10 });
+
+    assert.match(capturedUrl, /^https:\/\/graph\.facebook\.com\/v25\.0\/me\/adaccounts\?/);
+    assert.match(capturedUrl, /fields=id%2Cname/);
+    assert.match(capturedUrl, /limit=10/);
+    assert.match(capturedUrl, /access_token=meta-token-123/);
+  });
+
+  test('retries once on 401 and succeeds on second attempt', async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls += 1;
+
+      if (calls === 1) {
+        return jsonResponse(
+          { error: { message: 'Invalid OAuth access token.' } },
+          { ok: false, status: 401 }
+        );
+      }
+
+      return jsonResponse({ data: [{ id: '1' }] });
+    };
+
+    const { metaRequest } = await importFresh('../server/http.js');
+    const result = await metaRequest('/me/adaccounts');
+
+    assert.equal(calls, 2);
+    assert.equal(result.data.length, 1);
+  });
+
+  test('retries once on Graph rate-limit error code 17', async () => {
+    let calls = 0;
+    let slept = false;
+
+    global.fetch = async () => {
+      calls += 1;
+
+      if (calls === 1) {
+        return jsonResponse(
+          { error: { code: 17, message: 'User request limit reached' } },
+          { ok: false, status: 400 }
+        );
+      }
+
+      return jsonResponse({ data: [{ id: '1' }] });
+    };
+
+    const { metaRequest } = await importFresh('../server/http.js');
+    const result = await metaRequest(
+      '/me/adaccounts',
+      {},
+      {
+        sleep: async () => {
+          slept = true;
+        }
+      }
+    );
+
+    assert.equal(calls, 2);
+    assert.equal(slept, true);
+    assert.equal(result.data.length, 1);
+  });
+
+  test('retries once on HTTP 429', async () => {
+    let calls = 0;
+    let slept = false;
+
+    global.fetch = async () => {
+      calls += 1;
+
+      if (calls === 1) {
+        return jsonResponse(
+          { error: { message: 'Too many requests' } },
+          { ok: false, status: 429 }
+        );
+      }
+
+      return jsonResponse({ data: [{ id: '1' }] });
+    };
+
+    const { metaRequest } = await importFresh('../server/http.js');
+    const result = await metaRequest(
+      '/me/adaccounts',
+      {},
+      {
+        sleep: async () => {
+          slept = true;
+        }
+      }
+    );
+
+    assert.equal(calls, 2);
+    assert.equal(slept, true);
+    assert.equal(result.data.length, 1);
+  });
+
+  test('throws extracted Graph API error message', async () => {
+    global.fetch = async () => jsonResponse(
+      { error: { message: 'Unsupported get request.' } },
+      { ok: false, status: 400 }
+    );
+
+    const { metaRequest } = await importFresh('../server/http.js');
+
+    await assert.rejects(
+      () => metaRequest('/me/adaccounts'),
+      /Unsupported get request/
+    );
+  });
+
+  test('throws after repeated 401 failures (single retry only)', async () => {
+    let calls = 0;
+
+    global.fetch = async () => {
+      calls += 1;
+      return jsonResponse(
+        { error: { message: 'Invalid OAuth access token.' } },
+        { ok: false, status: 401 }
+      );
+    };
+
+    const { metaRequest } = await importFresh('../server/http.js');
+
+    await assert.rejects(
+      () => metaRequest('/me/adaccounts'),
+      /Invalid OAuth access token/
+    );
+
+    assert.equal(calls, 2);
+  });
+});

--- a/meta-ads/test/list-accounts.test.js
+++ b/meta-ads/test/list-accounts.test.js
@@ -1,0 +1,74 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { listAccounts } from '../server/tools/list-accounts.js';
+import { MOCK_LIST_ACCOUNTS_RESPONSE } from './fixtures.js';
+
+function parseResult(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('listAccounts', () => {
+  test('lists and normalizes account data', async () => {
+    const result = await listAccounts(
+      {},
+      {
+        request: async () => MOCK_LIST_ACCOUNTS_RESPONSE
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 2);
+
+    const first = body.data[0];
+    assert.equal(first.id, '1234567890');
+    assert.equal(first.status, 'ACTIVE');
+    assert.equal(first.currency, 'USD');
+    assert.equal(first.business_name, 'Channel47 LLC');
+  });
+
+  test('applies status filter', async () => {
+    const result = await listAccounts(
+      { status: 'DISABLED' },
+      {
+        request: async () => MOCK_LIST_ACCOUNTS_RESPONSE
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].status, 'DISABLED');
+  });
+
+  test('passes expected fields to API', async () => {
+    let capturedParams = null;
+
+    await listAccounts(
+      {},
+      {
+        request: async (_path, params) => {
+          capturedParams = params;
+          return { data: [] };
+        }
+      }
+    );
+
+    assert.equal(capturedParams.fields, 'id,name,account_status,currency,timezone_name,business{name}');
+  });
+
+  test('throws when API request fails', async () => {
+    await assert.rejects(
+      () => listAccounts(
+        {},
+        {
+          request: async () => {
+            throw new Error('Meta API unavailable');
+          }
+        }
+      ),
+      /Meta API unavailable/
+    );
+  });
+});

--- a/meta-ads/test/mutate-operations.test.js
+++ b/meta-ads/test/mutate-operations.test.js
@@ -1,0 +1,142 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateOperations,
+  buildApiRequest,
+  buildRequestPreview
+} from '../server/utils/mutate-operations.js';
+
+describe('validateOperations', () => {
+  test('returns no errors for valid create operation', () => {
+    const ops = [
+      {
+        entity: 'campaign',
+        action: 'create',
+        params: {
+          name: 'Test Campaign',
+          objective: 'OUTCOME_TRAFFIC'
+        }
+      }
+    ];
+
+    const errors = validateOperations(ops);
+    assert.equal(errors.length, 0);
+  });
+
+  test('returns errors for unsupported entity and missing params', () => {
+    const ops = [
+      {
+        entity: 'keyword',
+        action: 'create',
+        params: {}
+      },
+      {
+        entity: 'campaign',
+        action: 'update',
+        params: {
+          status: 'PAUSED'
+        }
+      }
+    ];
+
+    const errors = validateOperations(ops);
+    assert.equal(errors.length, 2);
+    assert.match(errors[0].message, /Unsupported entity/);
+    assert.match(errors[1].message, /requires id/);
+  });
+});
+
+describe('buildApiRequest', () => {
+  test('builds campaign create request on account endpoint', () => {
+    const request = buildApiRequest(
+      {
+        entity: 'campaign',
+        action: 'create',
+        params: {
+          name: 'Campaign A'
+        }
+      },
+      '12345'
+    );
+
+    assert.equal(request.method, 'POST');
+    assert.equal(request.path, '/act_12345/campaigns');
+    assert.equal(request.params.name, 'Campaign A');
+  });
+
+  test('builds pause action as update with PAUSED status', () => {
+    const request = buildApiRequest(
+      {
+        entity: 'adset',
+        action: 'pause',
+        id: '98765'
+      },
+      '12345'
+    );
+
+    assert.equal(request.method, 'POST');
+    assert.equal(request.path, '/98765');
+    assert.equal(request.params.status, 'PAUSED');
+  });
+
+  test('builds enable action as update with ACTIVE status', () => {
+    const request = buildApiRequest(
+      {
+        entity: 'ad',
+        action: 'enable',
+        id: '55555'
+      },
+      '12345'
+    );
+
+    assert.equal(request.method, 'POST');
+    assert.equal(request.path, '/55555');
+    assert.equal(request.params.status, 'ACTIVE');
+  });
+
+  test('builds delete action request', () => {
+    const request = buildApiRequest(
+      {
+        entity: 'audience',
+        action: 'delete',
+        id: '22222'
+      },
+      '12345'
+    );
+
+    assert.equal(request.method, 'DELETE');
+    assert.equal(request.path, '/22222');
+    assert.deepEqual(request.params, {});
+  });
+});
+
+describe('buildRequestPreview', () => {
+  test('returns human-readable preview for all operations', () => {
+    const preview = buildRequestPreview(
+      [
+        {
+          entity: 'campaign',
+          action: 'create',
+          params: {
+            name: 'Campaign A'
+          }
+        },
+        {
+          entity: 'campaign',
+          action: 'update',
+          id: '9001',
+          params: {
+            daily_budget: '5000'
+          }
+        }
+      ],
+      '12345'
+    );
+
+    assert.equal(preview.requests.length, 2);
+    assert.equal(preview.requests[0].path, '/act_12345/campaigns');
+    assert.equal(preview.requests[1].path, '/9001');
+    assert.equal(preview.requests[1].method, 'POST');
+  });
+});

--- a/meta-ads/test/mutate.test.js
+++ b/meta-ads/test/mutate.test.js
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mutate } from '../server/tools/mutate.js';
+import {
+  MOCK_MUTATE_CREATE_RESPONSE,
+  MOCK_MUTATE_UPDATE_RESPONSE,
+  MOCK_MUTATE_DELETE_RESPONSE
+} from './fixtures.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function parseResult(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  process.env.META_ADS_ACCOUNT_ID = '1234567890';
+  delete process.env.META_ADS_READ_ONLY;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('mutate - dry run', () => {
+  test('defaults to dry_run=true and returns request preview', async () => {
+    const result = await mutate({
+      operations: [
+        {
+          entity: 'campaign',
+          action: 'create',
+          params: {
+            name: 'Campaign A'
+          }
+        }
+      ]
+    });
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.metadata.dryRun, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].path, '/act_1234567890/campaigns');
+  });
+
+  test('returns validation errors for invalid operations', async () => {
+    await assert.rejects(
+      () => mutate({
+        operations: [
+          {
+            entity: 'campaign',
+            action: 'update',
+            params: {
+              status: 'PAUSED'
+            }
+          }
+        ]
+      }),
+      /Invalid operations/
+    );
+  });
+});
+
+describe('mutate - live execution', () => {
+  test('executes operations and returns per-operation results', async () => {
+    const calls = [];
+
+    const result = await mutate(
+      {
+        operations: [
+          {
+            entity: 'campaign',
+            action: 'create',
+            params: {
+              name: 'Campaign A'
+            }
+          },
+          {
+            entity: 'campaign',
+            action: 'update',
+            id: '9001',
+            params: {
+              daily_budget: '7500'
+            }
+          },
+          {
+            entity: 'campaign',
+            action: 'delete',
+            id: '9002'
+          }
+        ],
+        dry_run: false
+      },
+      {
+        request: async (path, params, options) => {
+          calls.push({ path, params, options });
+          if (options.method === 'DELETE') {
+            return MOCK_MUTATE_DELETE_RESPONSE;
+          }
+          if (path === '/act_1234567890/campaigns') {
+            return MOCK_MUTATE_CREATE_RESPONSE;
+          }
+          return MOCK_MUTATE_UPDATE_RESPONSE;
+        }
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.metadata.dryRun, false);
+    assert.equal(body.metadata.operationCount, 3);
+    assert.equal(body.metadata.succeeded, 3);
+    assert.equal(calls.length, 3);
+    assert.equal(calls[0].path, '/act_1234567890/campaigns');
+    assert.equal(calls[1].path, '/9001');
+    assert.equal(calls[2].options.method, 'DELETE');
+  });
+
+  test('continues on per-operation failure when partial_failure=true', async () => {
+    const result = await mutate(
+      {
+        operations: [
+          {
+            entity: 'campaign',
+            action: 'update',
+            id: '111',
+            params: {
+              status: 'PAUSED'
+            }
+          },
+          {
+            entity: 'campaign',
+            action: 'update',
+            id: '222',
+            params: {
+              status: 'ACTIVE'
+            }
+          }
+        ],
+        dry_run: false,
+        partial_failure: true
+      },
+      {
+        request: async (path) => {
+          if (path === '/111') {
+            throw new Error('Request failed for 111');
+          }
+          return { success: true };
+        }
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.metadata.failed, 1);
+    assert.equal(body.metadata.succeeded, 1);
+  });
+
+  test('stops on first failure when partial_failure=false', async () => {
+    let calls = 0;
+
+    await assert.rejects(
+      () => mutate(
+        {
+          operations: [
+            {
+              entity: 'campaign',
+              action: 'update',
+              id: '111',
+              params: {
+                status: 'PAUSED'
+              }
+            },
+            {
+              entity: 'campaign',
+              action: 'update',
+              id: '222',
+              params: {
+                status: 'ACTIVE'
+              }
+            }
+          ],
+          dry_run: false,
+          partial_failure: false
+        },
+        {
+          request: async () => {
+            calls += 1;
+            throw new Error('Request failed');
+          }
+        }
+      ),
+      /All 1 operation\(s\) failed/
+    );
+
+    assert.equal(calls, 1);
+  });
+
+  test('throws when read-only mode is enabled', async () => {
+    process.env.META_ADS_READ_ONLY = 'true';
+
+    await assert.rejects(
+      () => mutate(
+        {
+          operations: [
+            {
+              entity: 'campaign',
+              action: 'create',
+              params: {
+                name: 'Campaign A'
+              }
+            }
+          ],
+          dry_run: false
+        },
+        {
+          request: async () => ({ id: '1' })
+        }
+      ),
+      /read-only/
+    );
+  });
+
+  test('throws when all live operations fail', async () => {
+    await assert.rejects(
+      () => mutate(
+        {
+          operations: [
+            {
+              entity: 'campaign',
+              action: 'update',
+              id: '111',
+              params: {
+                status: 'PAUSED'
+              }
+            }
+          ],
+          dry_run: false
+        },
+        {
+          request: async () => {
+            throw new Error('Meta API down');
+          }
+        }
+      ),
+      /All 1 operation\(s\) failed/
+    );
+  });
+});

--- a/meta-ads/test/query.test.js
+++ b/meta-ads/test/query.test.js
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { query } from '../server/tools/query.js';
+import {
+  MOCK_QUERY_CAMPAIGNS_PAGE_1,
+  MOCK_QUERY_CAMPAIGNS_PAGE_2,
+  MOCK_INSIGHTS_RESPONSE
+} from './fixtures.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function parseResult(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  process.env.META_ADS_ACCOUNT_ID = '1234567890';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('query', () => {
+  test('queries campaigns with default fields and normalized account id', async () => {
+    let capturedPath = null;
+    let capturedParams = null;
+
+    const result = await query(
+      {
+        entity: 'campaigns'
+      },
+      {
+        request: async (path, params) => {
+          capturedPath = path;
+          capturedParams = params;
+          return { data: [] };
+        }
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(capturedPath, '/act_1234567890/campaigns');
+    assert.match(capturedParams.fields, /objective/);
+  });
+
+  test('handles cursor-based pagination up to requested limit', async () => {
+    let calls = 0;
+
+    const result = await query(
+      {
+        account_id: 'act_1234567890',
+        entity: 'campaigns',
+        limit: 3
+      },
+      {
+        request: async (_path, params) => {
+          calls += 1;
+          if (params.after === 'cursor_page_2') {
+            return MOCK_QUERY_CAMPAIGNS_PAGE_2;
+          }
+          return MOCK_QUERY_CAMPAIGNS_PAGE_1;
+        }
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 3);
+    assert.equal(calls, 2);
+  });
+
+  test('builds insights time_range from preset', async () => {
+    let capturedParams = null;
+
+    const result = await query(
+      {
+        account_id: '1234567890',
+        entity: 'insights',
+        date_range: 'yesterday',
+        level: 'campaign',
+        time_increment: 1
+      },
+      {
+        request: async (_path, params) => {
+          capturedParams = params;
+          return MOCK_INSIGHTS_RESPONSE;
+        }
+      }
+    );
+
+    const body = parseResult(result);
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(capturedParams.level, 'campaign');
+    assert.equal(capturedParams.time_increment, '1');
+
+    const timeRange = JSON.parse(capturedParams.time_range);
+    assert.ok(timeRange.since);
+    assert.ok(timeRange.until);
+  });
+
+  test('serializes filters and sort params', async () => {
+    let capturedParams = null;
+
+    await query(
+      {
+        account_id: '1234567890',
+        entity: 'adsets',
+        filters: [{ field: 'effective_status', operator: 'IN', value: ['ACTIVE'] }],
+        sort: 'name_ascending'
+      },
+      {
+        request: async (_path, params) => {
+          capturedParams = params;
+          return { data: [] };
+        }
+      }
+    );
+
+    assert.equal(capturedParams.sort, 'name_ascending');
+    assert.equal(
+      capturedParams.filtering,
+      JSON.stringify([{ field: 'effective_status', operator: 'IN', value: ['ACTIVE'] }])
+    );
+  });
+
+  test('caps requested limit at 1000', async () => {
+    let capturedParams = null;
+
+    await query(
+      {
+        account_id: '1234567890',
+        entity: 'campaigns',
+        limit: 5000
+      },
+      {
+        request: async (_path, params) => {
+          capturedParams = params;
+          return { data: [] };
+        }
+      }
+    );
+
+    assert.equal(capturedParams.limit, '1000');
+  });
+
+  test('throws on unsupported entity', async () => {
+    await assert.rejects(
+      () => query({ account_id: '123', entity: 'keywords' }, { request: async () => ({ data: [] }) }),
+      /Invalid entity/
+    );
+  });
+
+  test('throws when account id is missing', async () => {
+    delete process.env.META_ADS_ACCOUNT_ID;
+
+    await assert.rejects(
+      () => query({ entity: 'campaigns' }, { request: async () => ({ data: [] }) }),
+      /META_ADS_ACCOUNT_ID/
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
         "bing-ads",
         "dataforseo",
         "google-ads",
+        "meta-ads",
         "nano-banana",
         "substack"
       ]
     },
     "bing-ads": {
       "name": "@channel47/bing-ads-mcp",
-      "version": "1.1.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -44,7 +45,7 @@
     },
     "google-ads": {
       "name": "@channel47/google-ads-mcp",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -58,12 +59,30 @@
         "node": ">=18.0.0"
       }
     },
+    "meta-ads": {
+      "name": "@channel47/meta-ads-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "meta-ads-mcp": "server/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@channel47/bing-ads-mcp": {
       "resolved": "bing-ads",
       "link": true
     },
     "node_modules/@channel47/google-ads-mcp": {
       "resolved": "google-ads",
+      "link": true
+    },
+    "node_modules/@channel47/meta-ads-mcp": {
+      "resolved": "meta-ads",
       "link": true
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bing-ads",
     "dataforseo",
     "google-ads",
+    "meta-ads",
     "nano-banana",
     "substack"
   ],


### PR DESCRIPTION
## Summary

- New MCP server for the Meta Marketing API (Graph API v25.0)
- 3 tools: `list_accounts`, `query`, `mutate` — matching what the meta-ads plugin expects
- Direct REST via native `fetch` (no SDK dependency), following bing-ads patterns
- `dry_run=true` default on mutations with client-side validation preview
- Structured query builder with entity routing, field defaults, cursor pagination, and insights date range presets
- 42 tests passing across 8 test files

## Tools

| Tool | Purpose | Pattern From |
|------|---------|-------------|
| `list_accounts` | Discover accessible Meta ad accounts | bing-ads |
| `query` | Read campaigns, ad sets, ads, insights, audiences, creatives | New (Meta-specific) |
| `mutate` | Create/update/pause/enable/delete with dry_run safety | bing-ads |

## Test plan

- [x] `cd meta-ads && npm test` — 42/42 passing
- [x] `cd .. && npm run test` — workspace tests pass
- [ ] Manual: set `META_ADS_ACCESS_TOKEN` and run `node server/index.js` to verify startup
- [ ] Manual: test `list_accounts` against a real Meta account
- [ ] Update meta-ads plugin `.mcp.json` to pin version after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)